### PR TITLE
Update latest execution signal to only replay values upon invocation

### DIFF
--- a/RACAction.xcodeproj/project.pbxproj
+++ b/RACAction.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3AEB4ADD1BA74D6F00299462 /* RACCommand+RACAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AEB4ADB1BA74D6F00299462 /* RACCommand+RACAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AEB4ADE1BA74D6F00299462 /* RACCommand+RACAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AEB4ADB1BA74D6F00299462 /* RACCommand+RACAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AEB4ADF1BA74D6F00299462 /* RACCommand+RACAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AEB4ADC1BA74D6F00299462 /* RACCommand+RACAction.m */; };
+		3AEB4AE01BA74D6F00299462 /* RACCommand+RACAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AEB4ADC1BA74D6F00299462 /* RACCommand+RACAction.m */; };
 		D09B0B581B0E66C700AC15A1 /* RACAction.h in Headers */ = {isa = PBXBuildFile; fileRef = D09B0B571B0E66C700AC15A1 /* RACAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D09B0B5E1B0E66C700AC15A1 /* RACAction.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0B521B0E66C700AC15A1 /* RACAction.framework */; };
 		D09B0B7E1B0E66FF00AC15A1 /* RACAction.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0B731B0E66FF00AC15A1 /* RACAction.framework */; };
@@ -15,8 +19,6 @@
 		D09B0BAF1B0E685500AC15A1 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0BAE1B0E685500AC15A1 /* ReactiveCocoa.framework */; };
 		D09B0BB11B0E689800AC15A1 /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0BAC1B0E684B00AC15A1 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D09B0BB31B0E68E000AC15A1 /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0BAE1B0E685500AC15A1 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D09B0BB81B0E725C00AC15A1 /* RACAction.m in Sources */ = {isa = PBXBuildFile; fileRef = D09B0BB51B0E725C00AC15A1 /* RACAction.m */; };
-		D09B0BB91B0E725C00AC15A1 /* RACAction.m in Sources */ = {isa = PBXBuildFile; fileRef = D09B0BB51B0E725C00AC15A1 /* RACAction.m */; };
 		D09B0BBC1B0E73EF00AC15A1 /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0BBA1B0E73EF00AC15A1 /* Expecta.framework */; };
 		D09B0BBD1B0E73EF00AC15A1 /* Specta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0BBB1B0E73EF00AC15A1 /* Specta.framework */; };
 		D09B0BC01B0E73F800AC15A1 /* Expecta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09B0BBE1B0E73F800AC15A1 /* Expecta.framework */; };
@@ -76,6 +78,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3AEB4ADB1BA74D6F00299462 /* RACCommand+RACAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RACCommand+RACAction.h"; sourceTree = "<group>"; };
+		3AEB4ADC1BA74D6F00299462 /* RACCommand+RACAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RACCommand+RACAction.m"; sourceTree = "<group>"; };
 		D09B0B521B0E66C700AC15A1 /* RACAction.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RACAction.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D09B0B561B0E66C700AC15A1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D09B0B571B0E66C700AC15A1 /* RACAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RACAction.h; sourceTree = "<group>"; };
@@ -105,7 +109,6 @@
 		D09B0BA91B0E676C00AC15A1 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		D09B0BAC1B0E684B00AC15A1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/iOS/ReactiveCocoa.framework; sourceTree = SOURCE_ROOT; };
 		D09B0BAE1B0E685500AC15A1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/Mac/ReactiveCocoa.framework; sourceTree = SOURCE_ROOT; };
-		D09B0BB51B0E725C00AC15A1 /* RACAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACAction.m; sourceTree = "<group>"; };
 		D09B0BBA1B0E73EF00AC15A1 /* Expecta.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Expecta.framework; path = Carthage/Build/iOS/Expecta.framework; sourceTree = SOURCE_ROOT; };
 		D09B0BBB1B0E73EF00AC15A1 /* Specta.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Specta.framework; path = Carthage/Build/iOS/Specta.framework; sourceTree = SOURCE_ROOT; };
 		D09B0BBE1B0E73F800AC15A1 /* Expecta.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Expecta.framework; path = Carthage/Build/Mac/Expecta.framework; sourceTree = SOURCE_ROOT; };
@@ -178,7 +181,8 @@
 			isa = PBXGroup;
 			children = (
 				D09B0B571B0E66C700AC15A1 /* RACAction.h */,
-				D09B0BB51B0E725C00AC15A1 /* RACAction.m */,
+				3AEB4ADB1BA74D6F00299462 /* RACCommand+RACAction.h */,
+				3AEB4ADC1BA74D6F00299462 /* RACCommand+RACAction.m */,
 				D09B0B551B0E66C700AC15A1 /* Supporting Files */,
 			);
 			path = RACAction;
@@ -322,6 +326,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AEB4ADD1BA74D6F00299462 /* RACCommand+RACAction.h in Headers */,
 				D09B0B581B0E66C700AC15A1 /* RACAction.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -330,6 +335,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AEB4ADE1BA74D6F00299462 /* RACCommand+RACAction.h in Headers */,
 				D09B0BAA1B0E681600AC15A1 /* RACAction.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -490,7 +496,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D09B0BB81B0E725C00AC15A1 /* RACAction.m in Sources */,
+				3AEB4ADF1BA74D6F00299462 /* RACCommand+RACAction.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,7 +512,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D09B0BB91B0E725C00AC15A1 /* RACAction.m in Sources */,
+				3AEB4AE01BA74D6F00299462 /* RACCommand+RACAction.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RACAction/RACAction.h
+++ b/RACAction/RACAction.h
@@ -29,15 +29,16 @@ FOUNDATION_EXPORT const unsigned char RACActionVersionString[];
 /// deallocated.
 @property (nonatomic, strong, readonly) RACSignal *act_values;
 
-/// Replays the latest inner signal sent upon -act_executions, including any
-/// error or completed event.
+/// Replays the latest inner signal sent upon -act_executions following the
+/// invocation of this getter, including any error or completed event.
 ///
 /// Different subscriptions to this signal may connect to different executions
 /// of the action.
 ///
-/// Returns a signal that, upon subscription, will replay events from the
-/// current execution so far, then forward any future events, or else the
-/// previous execution if the action is not currently executing.
+/// Returns a signal that, upon subscription, will replay events from any
+/// executions following the invocation of this getter, then forward any future
+/// events, or else the previous execution if the action is not currently
+/// executing.
 @property (nonatomic, strong, readonly) RACSignal *act_latestExecution;
 
 @property (atomic, assign) BOOL allowsConcurrentExecution __attribute__((unavailable("RACActions are required to be serial")));

--- a/RACAction/RACAction.h
+++ b/RACAction/RACAction.h
@@ -14,34 +14,4 @@ FOUNDATION_EXPORT double RACActionVersionNumber;
 //! Project version string for RACAction.
 FOUNDATION_EXPORT const unsigned char RACActionVersionString[];
 
-/// Extends RACCommand with methods like those of Action from the RAC 3.0 Swift
-/// API.
-@interface RACAction : RACCommand
-
-/// A signal of inner signals representing each execution of this action.
-///
-/// Unlike -[RACCommand executionSignals], the inner signals here may error out.
-@property (nonatomic, strong, readonly) RACSignal *act_executions;
-
-/// The values sent by all executions of this action.
-///
-/// This signal will never error, and will complete when the action is
-/// deallocated.
-@property (nonatomic, strong, readonly) RACSignal *act_values;
-
-/// Replays the latest inner signal sent upon -act_executions following the
-/// invocation of this getter, including any error or completed event.
-///
-/// Different subscriptions to this signal may connect to different executions
-/// of the action.
-///
-/// Returns a signal that, upon subscription, will replay events from any
-/// executions following the invocation of this getter, then forward any future
-/// events, or else the previous execution if the action is not currently
-/// executing.
-@property (nonatomic, strong, readonly) RACSignal *act_latestExecution;
-
-@property (atomic, assign) BOOL allowsConcurrentExecution __attribute__((unavailable("RACActions are required to be serial")));
-@property (nonatomic, strong, readonly) RACSignal *executionSignals __attribute__((unavailable("Use -act_executions instead")));
-
-@end
+#import <RACAction/RACCommand+RACAction.h>

--- a/RACAction/RACAction.m
+++ b/RACAction/RACAction.m
@@ -10,19 +10,6 @@
 
 @implementation RACAction
 
-- (instancetype)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(id input))signalBlock {
-    self = [super initWithEnabled:enabledSignal signalBlock:signalBlock];
-    if (self == nil) return nil;
-
-    _act_latestExecution = [[[[self.act_executions
-        replayLast]
-        take:1]
-        flatten]
-        setNameWithFormat:@"%@ -act_latestExecution", self];
-
-    return self;
-}
-
 - (RACSignal *)act_executions {
     NSAssert(!super.allowsConcurrentExecution, @"RACActions are required to be serial, but %@ has concurreny enabled", self);
 
@@ -50,6 +37,14 @@
     return [[super.executionSignals
         concat]
         setNameWithFormat:@"%@ -act_values", self];
+}
+
+- (RACSignal *)act_latestExecution {
+    return [[[[self.act_executions
+        replayLast]
+        take:1]
+        flatten]
+        setNameWithFormat:@"%@ -act_latestExecution", self];
 }
 
 #pragma mark - RACCommand

--- a/RACAction/RACCommand+RACAction.h
+++ b/RACAction/RACCommand+RACAction.h
@@ -36,6 +36,6 @@
 /// executions following the invocation of this getter, then forward any future
 /// events, or else the previous execution if the action is not currently
 /// executing.
-@property (nonatomic, strong, readonly) RACSignal *act_latestExecution;
+@property (nonatomic, strong, readonly) RACSignal *act_nextExecution;
 
 @end

--- a/RACAction/RACCommand+RACAction.h
+++ b/RACAction/RACCommand+RACAction.h
@@ -1,0 +1,41 @@
+//
+//  RACCommand+RACAction.h
+//  RACAction
+//
+//  Created by Eric Horacek on 9/14/15.
+//  Copyright (c) 2015 Automatic. All rights reserved.
+//
+
+@import ReactiveCocoa;
+
+/// Extends RACCommand with methods like those of Action from the RAC 3.0 Swift
+/// API.
+@interface RACCommand (RACAction)
+
+/// A signal of inner signals representing each execution of this action.
+///
+/// The receiver must have allowsConcurrentExecution set to YES to invoke this
+/// getter. If not enabled, an exception will be thrown.
+///
+/// Unlike -[RACCommand executionSignals], the inner signals here may error out.
+@property (nonatomic, strong, readonly) RACSignal *act_executions;
+
+/// The values sent by all executions of this action.
+///
+/// This signal will never error, and will complete when the action is
+/// deallocated.
+@property (nonatomic, strong, readonly) RACSignal *act_values;
+
+/// Replays the latest inner signal sent upon -act_executions following the
+/// invocation of this getter, including any error or completed event.
+///
+/// Different subscriptions to this signal may connect to different executions
+/// of the action.
+///
+/// Returns a signal that, upon subscription, will replay events from any
+/// executions following the invocation of this getter, then forward any future
+/// events, or else the previous execution if the action is not currently
+/// executing.
+@property (nonatomic, strong, readonly) RACSignal *act_latestExecution;
+
+@end

--- a/RACAction/RACCommand+RACAction.m
+++ b/RACAction/RACCommand+RACAction.m
@@ -39,12 +39,12 @@
         setNameWithFormat:@"%@ -act_values", self];
 }
 
-- (RACSignal *)act_latestExecution {
+- (RACSignal *)act_nextExecution {
     return [[[[self.act_executions
         replayLast]
         take:1]
         flatten]
-        setNameWithFormat:@"%@ -act_latestExecution", self];
+        setNameWithFormat:@"%@ -act_nextExecution", self];
 }
 
 @end

--- a/RACAction/RACCommand+RACAction.m
+++ b/RACAction/RACCommand+RACAction.m
@@ -1,17 +1,17 @@
 //
-//  RACAction.m
+//  RACCommand+RACAction.m
 //  RACAction
 //
-//  Created by Justin Spahr-Summers on 2015-05-21.
+//  Created by Eric Horacek on 9/14/15.
 //  Copyright (c) 2015 Automatic. All rights reserved.
 //
 
-#import "RACAction.h"
+#import "RACCommand+RACAction.h"
 
-@implementation RACAction
+@implementation RACCommand (RACAction)
 
 - (RACSignal *)act_executions {
-    NSAssert(!super.allowsConcurrentExecution, @"RACActions are required to be serial, but %@ has concurreny enabled", self);
+    NSAssert(!self.allowsConcurrentExecution, @"%@ is required to be serial to invoke %@, but %@ has concurreny enabled", NSStringFromClass(self.class), NSStringFromSelector(_cmd), self);
 
     RACSignal *errors = [self.errors flattenMap:^(NSError *error) {
         return [RACSignal error:error];
@@ -21,7 +21,7 @@
         return !executing.boolValue;
     }];
 
-    return [[super.executionSignals
+    return [[self.executionSignals
         map:^(RACSignal *execution) {
             return [[RACSignal
                 merge:@[
@@ -34,7 +34,7 @@
 }
 
 - (RACSignal *)act_values {
-    return [[super.executionSignals
+    return [[self.executionSignals
         concat]
         setNameWithFormat:@"%@ -act_values", self];
 }
@@ -46,10 +46,5 @@
         flatten]
         setNameWithFormat:@"%@ -act_latestExecution", self];
 }
-
-#pragma mark - RACCommand
-
-@dynamic allowsConcurrentExecution;
-@dynamic executionSignals;
 
 @end

--- a/RACActionTests/RACActionSpec.m
+++ b/RACActionTests/RACActionSpec.m
@@ -100,10 +100,10 @@ describe(@"-act_values", ^{
     });
 });
 
-describe(@"-act_latestExecution", ^{
+describe(@"-act_nextExecution", ^{
     it(@"should forward next execution", ^{
         NSMutableArray *values = [NSMutableArray array];
-        [command.act_latestExecution subscribeNext:^(id value) {
+        [command.act_nextExecution subscribeNext:^(id value) {
             [values addObject:value];
         }];
         
@@ -113,7 +113,7 @@ describe(@"-act_latestExecution", ^{
 
     it(@"should send errors from execution", ^{
         __block NSError *receivedError = nil;
-        [command.act_latestExecution subscribeError:^(NSError *error) {
+        [command.act_nextExecution subscribeError:^(NSError *error) {
             receivedError = error;
         }];
         
@@ -124,7 +124,7 @@ describe(@"-act_latestExecution", ^{
 
     it(@"should replay last execution", ^{
         // The latest execution is replayed starting when it is first invoked.
-        RACSignal *latestExecution = command.act_latestExecution;
+        RACSignal *latestExecution = command.act_nextExecution;
 
         expect([[command execute:@2] asynchronouslyWaitUntilCompleted:NULL]).to.beTruthy();
         expect([latestExecution toArray]).to.equal((@[ @2, @4 ]));


### PR DESCRIPTION
Currently, act_latestExecution replays values from init-time onwards. However, this causes the latest values sent by the most recent execution signal to be cached indefinitely. In the case of having an action that infrequently sends values and has a long lifecycle, this can lead to retain-cycle-like behavior. To fix this, the act_latestExecution has been updated to replay values only upon invocation of the getter, rather than for the entire lifecycle of the action.